### PR TITLE
Test/work with page objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "faker": "^6.6.6"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.0.0",
@@ -28,7 +29,6 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
@@ -86,6 +86,11 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/faker": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
+      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^22.3.0"
   },
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "faker": "^6.6.6"
   }
 }

--- a/page-objects/alerts-frame-windows/browserWindowsPage.js
+++ b/page-objects/alerts-frame-windows/browserWindowsPage.js
@@ -1,0 +1,10 @@
+export class BrowserWindowsPage {
+    constructor(page) {
+      this.page = page;
+    }
+  
+    header() {
+      return this.page.getByRole('heading', { name: /browser windows/i });
+    }
+  }
+  

--- a/page-objects/book-store-application/bookStoreLoginPage.js
+++ b/page-objects/book-store-application/bookStoreLoginPage.js
@@ -1,0 +1,10 @@
+export class BookStoreLoginPage {
+    constructor(page) {
+      this.page = page;
+    }
+  
+    header() {
+      return this.page.locator('h1', { name: /login/i });
+    }
+  }
+  

--- a/page-objects/checkBox/checkBoxPage.js
+++ b/page-objects/checkBox/checkBoxPage.js
@@ -1,0 +1,21 @@
+export class CheckboxPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  header() {
+    return this.page.getByRole('heading', { name: /check box/i });
+  }
+
+  checkbox(name) {
+    return this.page.locator(`[for="tree-node-${name}"] .rct-checkbox`);
+  }
+
+  expandAllButton() {
+    return this.page.getByLabel(/expand all/i);
+  }
+
+  checkboxLocator() {
+    return this.page.locator('input[type="checkbox"]');
+  }
+}

--- a/page-objects/elements/textBoxPage.js
+++ b/page-objects/elements/textBoxPage.js
@@ -1,0 +1,24 @@
+export class TextBoxPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  header() {
+    return this.page.getByRole('heading', { name: /text box/i });
+  }
+
+  async fillOutForm(firstName, email, currentAddress, permanentAddress) {
+    await this.page
+      .getByRole('textbox', { name: /full name/i })
+      .fill(firstName);
+    await this.page
+      .getByRole('textbox', { name: /name@example.com/i })
+      .fill(email);
+    await this.page
+      .getByRole('textbox', { name: /current address/i })
+      .fill(currentAddress);
+    await this.page.locator('#permanentAddress').fill(permanentAddress);
+
+    await this.page.getByRole('button', { name: /submit/i }).click();
+  }
+}

--- a/page-objects/forms/practiceFormPage.js
+++ b/page-objects/forms/practiceFormPage.js
@@ -1,0 +1,9 @@
+export class PracticeFormPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  header() {
+    return this.page.getByRole('heading', { name: /practice form/i });
+  }
+}

--- a/page-objects/general/navigationPage.js
+++ b/page-objects/general/navigationPage.js
@@ -1,0 +1,72 @@
+export class NavigationPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async elementsPage() {
+    await this.page
+      .locator('.card', {
+        hasText: /elements/i,
+      })
+      .click();
+  }
+
+  async textBoxPage() {
+    await this.elementsPage();
+    await this.page.locator('li', { hasText: /text box/i }).click();
+  }
+
+  async checkBoxPage() {
+    await this.elementsPage();
+    await this.page.locator('li', { hasText: /check box/i }).click();
+  }
+
+  async formsPage() {
+    await this.page.locator('.card', { hasText: /forms/i }).click();
+  }
+
+  async practiceFormPage() {
+    await this.formsPage();
+    await this.page.locator('li', { hasText: /practice form/i }).click();
+  }
+
+  async alertsPage() {
+    await this.page
+      .locator('.card', { hasText: /alerts, frame & windows/i })
+      .click();
+  }
+
+  async browserWindows() {
+    await this.alertsPage();
+    await this.page.locator('li', { hasText: /browser windows/i }).click();
+  }
+
+  async widgetsPage() {
+    await this.page.locator('.card', { hasText: /widgets/i }).click();
+  }
+
+  async accordianPage() {
+    await this.widgetsPage();
+    await this.page.locator('li', { hasText: /accordian/i }).click();
+  }
+
+  async interactionsPage() {
+    await this.page.locator('.card', { hasText: /interactions/i }).click();
+  }
+
+  async sortablePage() {
+    await this.interactionsPage();
+    await this.page.locator('li', { hasText: /sortable/i }).click();
+  }
+
+  async bookStoreApplicationPage() {
+    await this.page
+      .locator('.card', { hasText: /book store application/i })
+      .click();
+  }
+
+  async bookStoreLoginPage() {
+    await this.bookStoreApplicationPage();
+    await this.page.locator('li', { hasText: /login/i }).click();
+  }
+}

--- a/page-objects/interactions/sortablePage.js
+++ b/page-objects/interactions/sortablePage.js
@@ -1,0 +1,10 @@
+export class SortablePage {
+    constructor(page) {
+      this.page = page;
+    }
+  
+    header() {
+      return this.page.getByRole('heading', { name: /sortable/i });
+    }
+  }
+  

--- a/page-objects/widget/accordianPage.js
+++ b/page-objects/widget/accordianPage.js
@@ -1,0 +1,9 @@
+export class AccordianPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  header() {
+    return this.page.getByRole('heading', { name: /accordian/i });
+  }
+}

--- a/tests/working_with_page_objects.spec.js
+++ b/tests/working_with_page_objects.spec.js
@@ -1,0 +1,109 @@
+import { test, expect } from '../utils/testFixtures';
+import { faker } from '@faker-js/faker';
+test.beforeEach(async ({ page }) => {
+  await page.goto('https://demoqa.com/', { waitUntil: 'commit' });
+});
+test('Submits Text Box Page Form', async ({
+  page,
+  navigationPage,
+  textBoxPage,
+}) => {
+  // Generate random data
+  const firstName = faker.person.firstName();
+  const email = faker.internet.email();
+  const currentAddress = faker.location.streetAddress();
+  const permanentAddress = faker.location.streetAddress();
+
+  await navigationPage.textBoxPage();
+  await expect(textBoxPage.header()).toBeVisible();
+
+  // Fill out the form with random data
+  await textBoxPage.fillOutForm(
+    firstName,
+    email,
+    currentAddress,
+    permanentAddress
+  );
+
+  // Assert input data is rendered in the DOM
+  await expect(page.locator('#name')).toHaveText(`Name:${firstName}`);
+  await expect(page.locator('#email')).toHaveText(`Email:${email}`);
+  await expect(page.locator('#output #currentAddress')).toHaveText(
+    `Current Address :${currentAddress}`
+  );
+  await expect(page.locator('#output #permanentAddress')).toHaveText(
+    `Permananet Address :${permanentAddress}`
+  );
+});
+test('Selects All Checkboxes in Checkbox Page', async ({
+  page,
+  navigationPage,
+  checkBoxPage,
+}) => {
+  const checkBoxLabelsText = [
+    'home',
+    'desktop',
+    'notes',
+    'commands',
+    'documents',
+    'workspace',
+    'react',
+    'angular',
+    'veu',
+    'office',
+    'public',
+    'private',
+    'classified',
+    'general',
+    'downloads',
+    'wordFile',
+    'excelFile',
+  ];
+
+  await navigationPage.checkBoxPage();
+  await expect(checkBoxPage.header()).toBeVisible();
+
+  await checkBoxPage.checkbox('home').click();
+  await expect(checkBoxPage.checkbox('home')).toBeChecked();
+
+  //assert expected text for labels selected is shown in the DOM
+  for (const label of checkBoxLabelsText) {
+    await expect(page.locator('#result')).toContainText(label);
+  }
+
+  // Expand all and assert all checkboxes are selected
+  await checkBoxPage.expandAllButton().click();
+
+  const checkboxesLocator = checkBoxPage.checkboxLocator();
+  const checkboxCount = await checkboxesLocator.count();
+
+  for (let i = 0; i < checkboxCount; i++) {
+    const checkbox = checkboxesLocator.nth(i);
+    const isChecked = await checkbox.isChecked();
+    expect(isChecked).toBe(true);
+  }
+});
+test('Forms Page', async ({ page, navigationPage, practiceFormPage }) => {
+  await navigationPage.practiceFormPage();
+  await expect(practiceFormPage.header()).toBeVisible();
+});
+test('Alerts Page', async ({ page, navigationPage, browserWindowsPage }) => {
+  await navigationPage.browserWindows();
+  await expect(browserWindowsPage.header()).toBeVisible();
+});
+test('Widgets Page', async ({ page, navigationPage, accordianPage }) => {
+  await navigationPage.accordianPage();
+  await expect(accordianPage.header()).toBeVisible();
+});
+test('Interactions Page', async ({ page, navigationPage, sortablePage }) => {
+  await navigationPage.sortablePage();
+  await expect(sortablePage.header()).toBeVisible();
+});
+test('Book Store Application Page', async ({
+  page,
+  navigationPage,
+  bookStoreLoginPage,
+}) => {
+  await navigationPage.bookStoreLoginPage();
+  await expect(bookStoreLoginPage.header()).toBeVisible();
+});

--- a/utils/testFixtures.ts
+++ b/utils/testFixtures.ts
@@ -1,11 +1,28 @@
-import { test as baseTest, expect } from '@playwright/test';
+import { test as baseTest, expect as baseExpect } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import { NavigationPage } from '../page-objects/general/navigationPage';
+import { BrowserWindowsPage } from '../page-objects/alerts-frame-windows/browserWindowsPage';
+import { BookStoreLoginPage } from '../page-objects/book-store-application/bookStoreLoginPage';
+import { CheckboxPage } from '../page-objects/checkBox/checkBoxPage';
+import { TextBoxPage } from '../page-objects/elements/textBoxPage';
+import { PracticeFormPage } from '../page-objects/forms/practiceFormPage';
+import { SortablePage } from '../page-objects/interactions/sortablePage';
+import { AccordianPage } from '../page-objects/widget/accordianPage';
 dotenv.config();
+export const expect = baseExpect;
 
 // Extend Playwright test with fixtures
 export const test = baseTest.extend<{
   authenticatedPage: any;
   accessToken: string;
+  browserWindowsPage: BrowserWindowsPage;
+  bookStoreLoginPage: BookStoreLoginPage;
+  checkBoxPage: CheckboxPage;
+  textBoxPage: TextBoxPage;
+  practiceFormPage: PracticeFormPage;
+  navigationPage: NavigationPage;
+  sortablePage: SortablePage;
+  accordianPage: AccordianPage;
 }>({
   // Define 'accessToken' fixture
   accessToken: async ({ request }, use) => {
@@ -51,5 +68,37 @@ export const test = baseTest.extend<{
 
     // Provide the authenticated page to the test
     await use(page);
+  },
+  // POM BrowserWindowsPage fixture
+  browserWindowsPage: async ({ page }, use) => {
+    await use(new BrowserWindowsPage(page));
+  },
+  // POM BooksStoreLoginPage fixture
+  bookStoreLoginPage: async ({ page }, use) => {
+    await use(new BookStoreLoginPage(page));
+  },
+  // POM CheckboxPage fixture
+  checkBoxPage: async ({ page }, use) => {
+    await use(new CheckboxPage(page));
+  },
+  // POM TextBoxPage fixture
+  textBoxPage: async ({ page }, use) => {
+    await use(new TextBoxPage(page));
+  },
+  // POM PracticeFormPage fixture
+  practiceFormPage: async ({ page }, use) => {
+    await use(new PracticeFormPage(page));
+  },
+  // POM NavigationPage fixture
+  navigationPage: async ({ page }, use) => {
+    await use(new NavigationPage(page));
+  },
+  // POM SortablePage fixture
+  sortablePage: async ({ page }, use) => {
+    await use(new SortablePage(page));
+  },
+  // POM AccordianPage fixture
+  accordianPage: async ({ page }, use) => {
+    await use(new AccordianPage(page));
   },
 });


### PR DESCRIPTION
- Extend the base Playwright test to import POMs, making them available throughout the project without needing to instantiate them within individual test files.